### PR TITLE
Added date format to fix overlapping text.

### DIFF
--- a/Contents/Resources/Content.html
+++ b/Contents/Resources/Content.html
@@ -1,6 +1,6 @@
 <div class="x-container c %messageClasses% %userIcons%">
 	<div class="a"><img class="x-buddyicon i" src="%userIconPath%" style="background:%senderColor%" alt="%sender%<" /></div>
-	<div class="x-time t" title="%time{dd MMM yyyy}%">%time%</div>
+	<div class="x-time t" title="%time{dd MMM yyyy}%">%time{dd MMM yyyy}%</div>
 	<div class="x-sender s" style="color: %senderColor%;" title="%senderPrefix%&nbsp;%senderScreenName%">%sender%</div>
 	<div class="x-message m %service%" title="%service% %time%">%message%</div>
 	<div id="insert"></div>


### PR DESCRIPTION
Without this change the full date would be displayed (with seconds and months, etc.) overlapping with my message text. This fixes the issue.
